### PR TITLE
Fixed disappearing menu bug and duplicate submenus

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -36,13 +36,18 @@ def add_sdf_button(self, context):
 
 sdf_group_cache = {}
 shader_cat_list = []
+draw_menu_functions = []
 
 dir_path = os.path.dirname(__file__)
 
 # adapted from https://github.com/blender/blender/blob/master/release/scripts/modules/nodeitems_utils.py
 def shader_cat_generator():
     global shader_cat_list
+    global draw_menu_functions
+
     shader_cat_list = []
+    draw_menu_functions = []
+
     for item in sdf_group_cache.items():
 
         def custom_draw(self, context):
@@ -92,9 +97,10 @@ def shader_cat_generator():
                 return draw_menu
 
             bpy.utils.register_class(menu_type)
-            bpy.types.NODE_MT_sdf_menu.append(
-                generate_menu_draw(menu_type.bl_idname, menu_type.bl_label)
-            )
+            draw_menu = generate_menu_draw(menu_type.bl_idname, menu_type.bl_label)
+            bpy.types.NODE_MT_sdf_menu.append(draw_menu)
+
+            draw_menu_functions.append(draw_menu)
             shader_cat_list.append(menu_type)
 
 
@@ -194,6 +200,10 @@ def register():
 
 
 def unregister():
+    for func in draw_menu_functions:
+        bpy.types.NODE_MT_sdf_menu.remove(func)
+
     if hasattr(bpy.types, "NODE_MT_sdf_menu"):
         bpy.types.NODE_MT_add.remove(add_sdf_button)
+        bpy.utils.unregister_class(NODE_MT_sdf_menu)
     bpy.utils.unregister_class(NODE_OT_group_add)


### PR DESCRIPTION
Hey, it's been a bit, but I think I pretty much got to the bottom of this. I've tested this for versions 3.0, 3.1, and 3.2 so far, and the SDF menu no longer bugs out even after loading new templates or when enabling/disabling the addon.
As it turns out, both problems (the disappearing menu and the duplicating submenus), are caused by two separate things.

The short explanation would be that for the disappearing menu, it technically doesn't disappear. The menu exists, but just doesn't get appended to the Add menu. It has to do with the fact that the code for appending the SDF menu to the Add menu, _'...NODE_MT_add.append(add_sdf_button)'_, is under an if-block that doesn't get called when the SDF menu is already registered. You could pull that code out of the if-block, or you could just unregister the SDF menu during _unregister()_, and both'd stop it from disappearing.

As for the initial fix I suggested where it had duplicating submenus, it's because the draw functions appended to _'NODE_MT_sdf_menu'_ don't get removed during unregister. So the SDF menu not just contains the submenus from the most current call of _register()_, but also all the submenus from previous calls of _register()_, hence the duplicated submenus. This problem does currently happen even under the current source code, it's just that the problem is invisible because the previous bug makes the SDF menu disappear anyway.

Anyhows, if there's any more questions to why I've changed what I've changed, just feel free to ask them. Otherwise, have a nice day!
 